### PR TITLE
Added placeholder text for quickpick menu.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,9 +95,12 @@ export class TemplateController {
                 return;
             }
 
-            const prompt = "Which template would you like to use?";
+            const placeHolder = "Which template would you like to use?";
 
-            vscode.window.showQuickPick(templateNames).then(
+            vscode.window.showQuickPick(templateNames, {
+                placeHolder: placeHolder,
+                ignoreFocusOut: true
+            }).then(
                 (value) => {
                     resolve(Object.assign({}, data, {
                         templateName: value,
@@ -117,6 +120,7 @@ export class TemplateController {
 
             vscode.window.showInputBox({
                 prompt: prompt,
+                ignoreFocusOut: true,
                 value: ''
             }).then(
                 (value) => {


### PR DESCRIPTION
Also made it so that clicking outside of focus doesn’t close the quickpick and input boxes.  I kind of feel like this is a slightly better ux but still not the greatest.  Currently when you press the escape key, I think it's submitting your input rather than canceling out of the workflow.  Think we need to look in to that next.

