### PR TITLE
[Resolve #13] -  Change how casing is defined in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Create custom file templates for your project.
 * Create a template group by adding a new folder under the blueprint templates storage folder
 * Add a template to the group by creating a new file
 
-![Use Alt](https://zippy.gfycat.com/EnormousResponsibleGander.gif)
+![Use Alt](https://zippy.gfycat.com/UnitedUnequaledFlounder.gif)
 
 ### Create from a template
 * Right click on the file or folder in the explorer
 * Select "New file from template"
 * Enter a name
 
-![Use Alt](https://zippy.gfycat.com/HalfBruisedHalcyon.gif)
+![Use Alt](https://zippy.gfycat.com/AggravatingBreakableDwarfmongoose.gif)
 
 ## Extension Settings
 

--- a/src/fileCreator.ts
+++ b/src/fileCreator.ts
@@ -16,11 +16,23 @@ export interface FileCreatorInputData {
 }
 
 interface ITemplateContext {
-    nameKebabCase: string;
-    nameSnakeCase: string;
-    namePascalCase: string;
-    nameCamelCase: string;
+    name: string;
 }
+
+handlebars.registerHelper({
+    kebabCase: function (string) {
+        return _.kebabCase(string);
+    },
+    camelCase: function (string) {
+        return _.camelCase(string);
+    },
+    pascalCase: function (string) {
+        return _.chain(string).camelCase().upperFirst().value();
+    },
+    snakeCase: function (string) {
+        return _.snakeCase(string);
+    }
+})
 
 function getTemplateFileNamesAtTemplateDirectory(templateFolderPath: string): string[] {
     const files = fs
@@ -33,13 +45,9 @@ function getTemplateFileNamesAtTemplateDirectory(templateFolderPath: string): st
 
 function getTemplateContext(name: string): ITemplateContext {
     return {
-        nameKebabCase: _.kebabCase(name),
-        nameCamelCase: _.camelCase(name),
-        namePascalCase: _.chain(name).camelCase().upperFirst().value(),
-        nameSnakeCase: _.snakeCase(name)
+        name: name
     }
 }
-
 export class FileCreator {
 
     constructor(private data: FileCreatorInputData) { }
@@ -65,10 +73,11 @@ export class FileCreator {
 
             if (options.createFilesInFolderWithPattern) {
                 const folderName = options.createFilesInFolderWithPattern
-                    .replace('__namekebabcase__', templateContext.nameKebabCase)
-                    .replace('__namepascalcase__', templateContext.namePascalCase)
-                    .replace('__namesnakecase__', templateContext.nameSnakeCase)
-                    .replace('__namecamalcase__', templateContext.nameCamelCase);
+                //is this the right place to be doing the string conversions?
+                    .replace('__kebabCase_name__', _.kebabCase(templateContext.name))
+                    .replace('__pascalCase_name__', _.chain(templateContext.name).camelCase().upperFirst().value())
+                    .replace('__snakeCase_name__', _.snakeCase(templateContext.name))
+                    .replace('__camelCase_name__', _.camelCase(templateContext.name));
                 directoryPathForFiles = this.data.pathToCreateAt + '/' + folderName;
             }
 
@@ -81,10 +90,11 @@ export class FileCreator {
             getTemplateFileNamesAtTemplateDirectory(templateDirectory).forEach(templateFileName => {
 
                 const fileNameToUse = templateFileName
-                    .replace('__namekebabcase__', templateContext.nameKebabCase)
-                    .replace('__namepascalcase__', templateContext.namePascalCase)
-                    .replace('__namesnakecase__', templateContext.nameSnakeCase)
-                    .replace('__namecamalcase__', templateContext.nameCamelCase);
+                //should we create a function to do the conversions since this is the same code used above?
+                    .replace('__kebabCase_name__', _.kebabCase(templateContext.name))
+                    .replace('__pascalCase_name__', _.chain(templateContext.name).camelCase().upperFirst().value())
+                    .replace('__snakeCase_name__', _.snakeCase(templateContext.name))
+                    .replace('__camelCase_name__', _.camelCase(templateContext.name));
                 const filePath = `${directoryPathForFiles}/${fileNameToUse}`;
                 const rawTemplateContent = fs.readFileSync(`${this.data.templateFolderPath}/${this.data.templateName}/${templateFileName}`, "utf8");
                 const template = handlebars.compile(rawTemplateContent);

--- a/src/fileCreator.ts
+++ b/src/fileCreator.ts
@@ -34,6 +34,14 @@ handlebars.registerHelper({
     }
 })
 
+function replaceName(stringToReplace: string, name: string) {
+    return stringToReplace
+        .replace('__kebabCase_name__', _.kebabCase(name))
+        .replace('__pascalCase_name__', _.chain(name).camelCase().upperFirst().value())
+        .replace('__snakeCase_name__', _.snakeCase(name))
+        .replace('__camelCase_name__', _.camelCase(name));
+}
+
 function getTemplateFileNamesAtTemplateDirectory(templateFolderPath: string): string[] {
     const files = fs
         .readdirSync(templateFolderPath)
@@ -72,12 +80,7 @@ export class FileCreator {
             let directoryPathForFiles = this.data.pathToCreateAt;
 
             if (options.createFilesInFolderWithPattern) {
-                const folderName = options.createFilesInFolderWithPattern
-                //is this the right place to be doing the string conversions?
-                    .replace('__kebabCase_name__', _.kebabCase(templateContext.name))
-                    .replace('__pascalCase_name__', _.chain(templateContext.name).camelCase().upperFirst().value())
-                    .replace('__snakeCase_name__', _.snakeCase(templateContext.name))
-                    .replace('__camelCase_name__', _.camelCase(templateContext.name));
+                const folderName = replaceName(options.createFilesInFolderWithPattern, templateContext.name);
                 directoryPathForFiles = this.data.pathToCreateAt + '/' + folderName;
             }
 
@@ -89,12 +92,7 @@ export class FileCreator {
 
             getTemplateFileNamesAtTemplateDirectory(templateDirectory).forEach(templateFileName => {
 
-                const fileNameToUse = templateFileName
-                //should we create a function to do the conversions since this is the same code used above?
-                    .replace('__kebabCase_name__', _.kebabCase(templateContext.name))
-                    .replace('__pascalCase_name__', _.chain(templateContext.name).camelCase().upperFirst().value())
-                    .replace('__snakeCase_name__', _.snakeCase(templateContext.name))
-                    .replace('__camelCase_name__', _.camelCase(templateContext.name));
+                const fileNameToUse = replaceName(templateFileName, templateContext.name);
                 const filePath = `${directoryPathForFiles}/${fileNameToUse}`;
                 const rawTemplateContent = fs.readFileSync(`${this.data.templateFolderPath}/${this.data.templateName}/${templateFileName}`, "utf8");
                 const template = handlebars.compile(rawTemplateContent);


### PR DESCRIPTION
Template syntax changed :
example: `{{nameKebabCase}}` is now `{{kebabCase name}}`

File name replace changed:
example: `__namekebabcase__` is now `__kebabCase_name__`

README usage gifs updated to reflect above changes.

Updates to blueprint-example templates can be pushed after this pull request is complete.