### PR TITLE
Add dangerfile and add to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 os:
   - linux
 
+rvm:
+  - 2.1.3
+
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,6 @@ before_script:
   - yarn run vscode:prepublish
 
 script:
+  - bundle exec danger
   - yarn lint
   - yarn test --silent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Add Dangerfile
 
 ## [1.1.0] - 2015-04-11
 - Fix mixing dependency in release

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,7 +1,7 @@
 # Require Changelog to be modified if more than 20 lines of code have to been changed and #trivial does not appear in pull request title
 declared_trivial = (github.pr_title + github.pr_body).include?("#trivial")
 if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
-  fail("Please include a CHANGELOG entry. \nYou can find it at #{github.html_link("CHANGELOG.md")}.", sticky: false)
+  fail("Please include an entry in #{github.html_link("CHANGELOG.md")}—if this is a trivial Pull Request that does not require a changelog entry please include #trivial in the title.", sticky: false)
 end
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
@@ -17,4 +17,4 @@ fail("fit left in tests") if `grep -r fit specs/ `.length > 1
 # Warn if there are changes to the package.json file. 
 warn "#{github.html_link("package.json")} was edited." if git.modified_files.include? "package.json"
 
-message("Thanks! :tada:");
+message(":tada:  Thanks for the Pull Request!");

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,20 @@
+# Require Changelog to be modified if more than 20 lines of code have to been changed and #trivial does not appear in pull request title
+declared_trivial = (github.pr_title + github.pr_body).include?("#trivial")
+if !git.modified_files.include?("CHANGELOG.md") && !declared_trivial
+  fail("Please include a CHANGELOG entry. \nYou can find it at #{github.html_link("CHANGELOG.md")}.", sticky: false)
+end
+
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+warn("PR is marked as Work in Progress") if github.pr_title.include? "[WIP]"
+
+# Warn when there is a big PR
+warn("Big PR - Consider breaking this into several smaller pull requests") if git.lines_of_code > 500
+
+# Don't let testing shortcuts get into master by accident
+fail("fdescribe left in tests") if `grep -r fdescribe specs/ `.length > 1
+fail("fit left in tests") if `grep -r fit specs/ `.length > 1
+
+# Warn if there are changes to the package.json file. 
+warn "#{github.html_link("package.json")} was edited." if git.modified_files.include? "package.json"
+
+message("Thanks! :tada:");

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem 'danger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    claide (1.0.1)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored2 (3.1.2)
+    cork (0.3.0)
+      colored2 (~> 3.1)
+    danger (5.0.3)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
+      octokit (~> 4.2)
+      terminal-table (~> 1)
+    faraday (0.12.0.1)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    git (1.3.0)
+    kramdown (1.13.2)
+    multipart-post (2.0.0)
+    nap (1.1.0)
+    octokit (4.7.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    public_suffix (2.0.5)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
+    unicode-display_width (1.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  danger
+
+BUNDLED WITH
+   1.12.3


### PR DESCRIPTION
This pull requests adds a Dangerfile and Danger as a step in the continuous integration.

Danger is a way to formalize rules in our Pull Requests. http://danger.systems

One rule for instance is making sure that if there are changes, that the Changelog.md file has also been modified (you can skip this by writing # trivial (no space) somewhere in the pull request).