### PR TITLE
[Resolves #34] Add ability to create nested folders in templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Can now have a nested folder structure!
 - Add Dangerfile
 
 ## [1.1.0] - 2015-04-11


### PR DESCRIPTION
You can now have a template folder structure like:

- Template name
  - __kebabCase_name__
    - __kebabCase_name__.component.ts

With a name of "Test" this would result in:

- test
  - test.component.ts

Assuming you didn't have the createFilesInFolderWithPattern in your manifest. If you did it would continue create that folder as well.