### PR TITLE
upperCase and lowerCase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ We will continue to add new templates that we think may be helpful to use!
 
 ## Release Notes
 
+### 2.1.0
+
+Added two new transform helper: lowerCase and upperCase.
+
 ### 2.0.0
 
 Adds ability to provide multiple folders of templates. Useful for using both a project local and a shared (global) templates.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Examples:
 
 | Helper Name  | Example Use In Templates | Example Use in File/Folder Names | Sample Result          |
 |--------------|--------------------------|----------------------------------|------------------------|
+| upperCase    | {{upperCase name}}       | \_\_upperCase_name\_\_               | THISISUPPERCASE        |
+| lowerCase    | {{lowerCase name}}       | \_\_lowerCase_name\_\_               | thisislowercase        |
 | camelCase    | {{camelCase name}}       | \_\_camelCase_name\_\_               | thisIsCamelCase        |
 | pascalCase   | {{pascalCase name}}      | \_\_pascalCase_name\_\_              | ThisIsPascalCase       |
 | snakeCase    | {{snakeCase name}}       | \_\_snakeCase_name\_\_               | this_is_snake_case     |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "blueprint",
   "displayName": "Blueprint - New Files and Folders of Files from Templates",
   "description": "Easily create files and folder of files from templates in Visual Studio Code",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "publisher": "teamchilla",
   "license": "MIT",
   "engines": {

--- a/src/fileCreator.ts
+++ b/src/fileCreator.ts
@@ -35,6 +35,9 @@ handlebars.registerHelper({
     snakeCase: (input) => {
         return _.snakeCase(input);
     },
+    upperCase: (input) => {
+        return _.upperCase(input);
+    }
 });
 
 function escapeRegExp(str): string {
@@ -51,6 +54,7 @@ function replaceName(stringToReplace: string, name: string): string {
     result = replaceAll(result, "__snakeCase_name__", _.snakeCase(name));
     result = replaceAll(result, "__lowerDotCase_name__", _.snakeCase(name).replace(/_/g, "."));
     result = replaceAll(result, "__camelCase_name__", _.camelCase(name));
+    result = replaceAll(result, "__upperCase_name__", _.upperCase(name));
     return result;
 }
 

--- a/src/fileCreator.ts
+++ b/src/fileCreator.ts
@@ -37,6 +37,9 @@ handlebars.registerHelper({
     },
     upperCase: (input) => {
         return _.upperCase(input);
+    },
+    lowerCase: (input) => {
+        return _.lowerCase(input);
     }
 });
 
@@ -55,6 +58,7 @@ function replaceName(stringToReplace: string, name: string): string {
     result = replaceAll(result, "__lowerDotCase_name__", _.snakeCase(name).replace(/_/g, "."));
     result = replaceAll(result, "__camelCase_name__", _.camelCase(name));
     result = replaceAll(result, "__upperCase_name__", _.upperCase(name));
+    result = replaceAll(result, "__lowerCase_name__", _.lowerCase(name));
     return result;
 }
 


### PR DESCRIPTION
Added upperCase and lowerCase support, useful for instances where the user has a template which requires these formats.

e.g. React action files (my use case) where a template action creator is needed:

`const SET_{{upperCase name}}_STATE = "{{pascalCase name}}/Set{{pascalCase name}}State";`