### PR TITLE
[Resolves #44] Cleans up quick pick user interface to emphasis template name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [2.1.0 - 2018-5-2]
-
+* Formats how templates are displayed in the selection menu
 * Added upperCase and lowerCase as a new replacement option.
 
 ## [2.0.0 - 2018-4-30]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 "use strict";
 
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 
@@ -20,28 +19,11 @@ export function activate(context: vscode.ExtensionContext) {
       directoryPath = path.dirname(directoryPath);
     }
 
-    const templateFolderRelativePaths = vscode.workspace
+    const templateFolderRawPaths = vscode.workspace
       .getConfiguration("blueprint")
       .get("templatesPath") as string[];
 
-    const templateFolderPaths = templateFolderRelativePaths.map((templatePath) => {
-
-      const normalizedPath = path.normalize(templatePath);
-      let result = templatePath;
-
-      if (normalizedPath.substring(0, 1) === "~") {
-        const home = os.homedir();
-        const subPath = normalizedPath.substring(1, normalizedPath.length);
-        result = path.join(home, subPath);
-      } else {
-        result = path.resolve(vscode.workspace.rootPath, templatePath);
-      }
-
-      return result;
-
-    });
-
-    const inputController = new InputController(templateFolderPaths, directoryPath);
+    const inputController = new InputController(templateFolderRawPaths, directoryPath);
 
     inputController.run()
       .then((data) => {

--- a/src/inputController.ts
+++ b/src/inputController.ts
@@ -10,7 +10,7 @@ import * as constants from "./constants";
 import { CancelError } from "./customErrors";
 import { IFileCreatorInputData } from "./fileCreator";
 
-interface TemplateQuickPickItem extends vscode.QuickPickItem {
+interface ITemplateQuickPickItem extends vscode.QuickPickItem {
     filePath: string;
 }
 
@@ -46,7 +46,7 @@ export class InputController {
     private showTemplatePickerDialog(templateFolderPaths: string[]): Promise<string> {
         return new Promise((resolve, reject) => {
 
-            const quickPickItems: TemplateQuickPickItem[] = templateFolderPaths
+            const quickPickItems: ITemplateQuickPickItem[] = templateFolderPaths
                 .map(folderPath => {
                     return this.quickPickItemsForFolder(folderPath);
                 })
@@ -82,17 +82,17 @@ export class InputController {
         });
     }
 
-    private quickPickItemsForFolder(folderPath: string): TemplateQuickPickItem[] {
+    private quickPickItemsForFolder(folderPath: string): ITemplateQuickPickItem[] {
         try {
             const expandedFolderPath = this.expandFolderPath(folderPath);
             const templateNames = this.availableTemplateNames(expandedFolderPath);
 
-            const items: TemplateQuickPickItem[] = templateNames.map((name, index) => {
+            const items: ITemplateQuickPickItem[] = templateNames.map((name, index) => {
                 return {
+                    description: index === 0 ? folderPath : "",
+                    filePath: path.join(expandedFolderPath, name),
                     label: name,
-                    description: index === 0 ? folderPath : '',
-                    filePath: path.join(expandedFolderPath, name)
-                }
+                };
             });
             return items;
 

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,8 @@
         "tslint:recommended"
     ],
     "jsRules": {},
-    "rules": {},
+    "rules": {
+        "arrow-parens": false
+    },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Template selection menu is now shown like this:

<img width="807" alt="screen shot 2018-05-04 at 4 35 17 pm" src="https://user-images.githubusercontent.com/850045/39657043-303430aa-4fb9-11e8-9c2a-9fb7dd5a3197.png">

The file name of the template is emphasized. The folder path it is contained with is only shown on the first template in that path and is deemphasized.