### PR TITLE
Update createFiles.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+### [Unreleased]
+
+## [3.0.1 - 2019-01-17]
+
+* Adds ability to use suffixesToIgnoreInInput without createFilesInFolderWithPattern
 
 ## [3.0.0 - 2019-01-02]
 

--- a/src/fileCreator/createFiles.ts
+++ b/src/fileCreator/createFiles.ts
@@ -23,7 +23,7 @@ export async function createFiles(userInput: IUserInput, inDirectory: string): P
   await createFilesFromTemplateInDirectory(
     userInput.selectedTemplatePath,
     temporaryDirectory,
-    userInput.inputName,
+    name,
     userInput.dynamicTemplateValues,
   );
 


### PR DESCRIPTION
Create file based on name instead of userInput.inputName

In my case, `suffixesToIgnoreInInput` doesn't work if isn't with `createFilesInFolderWithPattern`. 
However, `createFilesInFolderWithPattern` is being deprecated.