### PR TITLE
Added option to specify template version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Ability to choose from template versions (as sub-folders) defined in manifest.json
+
 ## [3.0.0 - 2019-01-02]
 
 * Adds ability to provide dynamic template replacements at the time of file creation

--- a/src/inputs/getTemplateVersionOptions.ts
+++ b/src/inputs/getTemplateVersionOptions.ts
@@ -1,0 +1,43 @@
+"use strict";
+
+import { Disposable, QuickPickItem, window } from "vscode";
+import { NoTemplateSelectedError } from "../errors";
+import { IMultiStepData } from "./getUserInput";
+
+interface ITemplateVersionQuickPickItem extends QuickPickItem {
+  folderName: string;
+}
+
+export async function getTemplateVersionFolder(
+  manifestTemplateVersions: ITemplateVersionQuickPickItem[],
+  multiStep: IMultiStepData,
+): Promise<string> {
+
+  const disposables: Disposable[] = [];
+  try {
+      return await new Promise<string>((resolve, reject) => {
+          const input = window.createQuickPick<QuickPickItem>();
+          input.items = manifestTemplateVersions.reduce((prev, curr) => {
+            return prev.concat(curr);
+          }, []);
+          input.placeholder = "Which template version would you like to use?";
+          input.ignoreFocusOut = true;
+          input.step = multiStep.step;
+          input.title = multiStep.title;
+          disposables.push(
+            input.onDidChangeSelection((items: any) => {
+              if (items.length === 0) {
+                reject(new NoTemplateSelectedError());
+                return;
+              }
+              resolve(items[0].folderName);
+              input.dispose();
+            }),
+          );
+
+          input.show();
+      });
+  } finally {
+      disposables.forEach(d => d.dispose());
+  }
+}

--- a/src/inputs/getUserInput.ts
+++ b/src/inputs/getUserInput.ts
@@ -1,9 +1,11 @@
 "use strict";
 
+import { getTemplateManifestAtTemplateDirectory } from "../getTemplateManifest";
 import { getTemplatePathDynamicTokens } from "../utilities/dynamicTokenSearch";
 import { getDesiredName } from "./getDesiredName";
 import { getDynamicTemplateInputForToken } from "./getDynamicTokenInput";
 import { getSelectedTemplatePath } from "./getSelectedTemplatePath";
+import { getTemplateVersionFolder } from "./getTemplateVersionOptions";
 
 export interface IUserInput {
     inputName: string;
@@ -25,10 +27,17 @@ export interface IDynamicTemplateValues {
 export async function getUserInput(availableTemplatePaths: string[]): Promise<IUserInput> {
     let stepCount = 1;
     const title = "New File from Template";
-    const selectedTemplatePath = await getSelectedTemplatePath(availableTemplatePaths, { step: stepCount++, title });
+    let selectedTemplatePath = await getSelectedTemplatePath(availableTemplatePaths, { step: stepCount++, title });
     const inputName = await getDesiredName({ step: stepCount++, title });
-    const dynamicTokens = await getTemplatePathDynamicTokens(selectedTemplatePath);
 
+    const manifestOptions = getTemplateManifestAtTemplateDirectory(selectedTemplatePath) as any;
+    if (!!manifestOptions.templateVersions) {
+        const versionFolder: string =
+            await getTemplateVersionFolder(manifestOptions.templateVersions, { step: stepCount++, title });
+        selectedTemplatePath = `${selectedTemplatePath}\\${versionFolder}`;
+    }
+
+    const dynamicTokens = await getTemplatePathDynamicTokens(selectedTemplatePath);
     const dynamicTemplateValues: IDynamicTemplateValues = {};
     for (const option of dynamicTokens) {
         const userInput = await getDynamicTemplateInputForToken(option, { step: stepCount++, title });


### PR DESCRIPTION
#### General Information
Hi @reesemclean, in this pull request i added extra functionality to be able to work with template versions. I think it could be a nice enhancement to the current functionality for the extension. 

#### Problem
I do a lot of react development so i created some templates for this. (e.g. a react component template). React components all have the same basic functionality, but can differ a bit in setup. For example you can have a 1 component.tsx file, 1 component.props.ts file and 1 component.state.ts file. But you could also put the props and state in 1 component.types.ts file (this is depending on the developer preferences). I do not wan't to create a blueprint template for each of these options, but rather add them as template version. 

#### Solution 
I added some functionality that will read the manifest.json and based on the configuration update the selectedTemplatePath. The templateVersions option in the manifest takes an array of all the template versions and specifies the label, description and sub-folder name. This implies that all template versions are created in sub-folders of the main template (example below). An extra user input is required to select the template version. if the templateVersions property is not defined in the manifest.json then the default behavior applies.

```json
"templateVersions": [
    {
      "label": "With types.ts file",
      "folderName": "reactComponent1TypesFile",
      "description": "React Component where the props and state object are in one .types object"
    },
    {
      "label": "With props.ts and state.ts file",
      "folderName": "reactComponent2TypesFile",
      "description": "React Component where the props and state object are in different files"
    }
  ]
```

**Please let me know what you think of the feature and if this is something that could be incorporated into the extension.**
