### PR TITLE
ignore .git folder

### DIFF
--- a/src/utilities/getTemplateFilesAndFolders.ts
+++ b/src/utilities/getTemplateFilesAndFolders.ts
@@ -76,6 +76,7 @@ function shouldIgnoreFileName(fileName: string): boolean {
     ".Trashes",
     "ehthumbs.db",
     "Thumbs.db",
+    ".git",
     constants.MANIFEST_FILE_NAME,
   ];
 


### PR DESCRIPTION
I would like to keep a global blueprints folder at at a higher directory from my projects and just link to the folder from each project. The pull request is because I would like to keep the global templates folder in github and for that reason I would like to ignore any templates named .git.  I'll admit I didn't dive into the code too deeply, so if this array is meant to ignore the files created from the templates rather than the templates themselves, that is not the effect I am going for.